### PR TITLE
feat(translate): Translate dashboard pages to Indonesian

### DIFF
--- a/src/app/dashboard/database/page.tsx
+++ b/src/app/dashboard/database/page.tsx
@@ -72,7 +72,7 @@ const Header = ({
           <div className="flex items-center px-3 py-2 bg-green-50 dark:bg-green-900 rounded-md">
             <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
             <span className="text-sm font-medium text-green-700 dark:text-green-300">
-              Approved
+              Disetujui
             </span>
           </div>
         </div>
@@ -104,7 +104,7 @@ const SearchBar = ({ setQuery, setFilter }: any) => {
             type="text"
             id="search-navbar"
             className="block w-full p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-            placeholder="Search..."
+            placeholder="Cari..."
             onChange={(e) => setKeyword(e.target.value)}
           />
         </form>
@@ -146,8 +146,8 @@ const Database: React.FC = () => {
       })
       .catch((error) => {
         toast({
-          title: "Error",
-          description: "Failed to fetch data",
+          title: "Kesalahan",
+          description: "Gagal mengambil data",
           variant: "destructive",
         });
       });
@@ -176,10 +176,10 @@ const Database: React.FC = () => {
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-            Access Denied
+            Akses Ditolak
           </h2>
           <p className="text-gray-600 dark:text-gray-400">
-            Please log in to access the database.
+            Silakan masuk untuk mengakses database.
           </p>
         </div>
       </div>

--- a/src/app/dashboard/inspector/page.tsx
+++ b/src/app/dashboard/inspector/page.tsx
@@ -100,8 +100,8 @@ const InspectorPage = () => {
     e.preventDefault();
     apiClient.post("/admin/users/inspector", formData, {}).then((response) => {
       toast({
-        title: "Inspector Added",
-        description: "New inspector has been added successfully.",
+        title: "Inspektor Ditambahkan",
+        description: "Inspektor baru telah berhasil ditambahkan.",
       });
       setIsDrawerOpen(false);
       setFormData({
@@ -206,8 +206,8 @@ const InspectorPage = () => {
       );
 
       toast({
-        title: "Inspector Updated",
-        description: `Inspector data has been updated successfully. ${
+        title: "Inspektor Diperbarui",
+        description: `Data inspektor telah berhasil diperbarui. ${
           Object.keys(changedData).length
         } field(s) changed.`,
       });
@@ -222,8 +222,8 @@ const InspectorPage = () => {
     } catch (error) {
       console.error("Update error:", error);
       toast({
-        title: "Update Failed",
-        description: "Failed to update inspector data.",
+        title: "Pembaruan Gagal",
+        description: "Gagal memperbarui data inspektor.",
         variant: "destructive",
       });
     }
@@ -239,10 +239,10 @@ const InspectorPage = () => {
           </div>
           <div>
             <h1 className="text-3xl font-bold bg-gradient-to-r from-orange-600 to-orange-400 bg-clip-text text-transparent">
-              Inspector Management
+              Manajemen Inspektor
             </h1>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              Manage and monitor all inspection personnel
+              Kelola dan pantau semua personel inspeksi
             </p>
           </div>
         </div>
@@ -252,23 +252,23 @@ const InspectorPage = () => {
           <DrawerTrigger asChild>
             <Button className="bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white shadow-lg">
               <FaPlus className="mr-2" />
-              Add Inspector
+              Tambah Inspektor
             </Button>
           </DrawerTrigger>
           <DrawerContent className="sm:max-w-[425px] fixed right-0 top-0 bottom-0 left-auto">
             <form onSubmit={handleSubmit}>
               <DrawerHeader>
-                <DrawerTitle>Add New Inspector</DrawerTitle>
+                <DrawerTitle>Tambah Inspektor Baru</DrawerTitle>
                 <DrawerDescription>
-                  Create a new inspector account with the required details.
+                  Buat akun inspektor baru dengan detail yang diperlukan.
                 </DrawerDescription>
               </DrawerHeader>
               <div className="mb-5  space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="name">Full Name</Label>
+                  <Label htmlFor="name">Nama Lengkap</Label>
                   <Input
                     id="name"
-                    placeholder="Enter inspector name"
+                    placeholder="Masukkan nama inspektor"
                     value={formData.name}
                     onChange={(e) =>
                       setFormData({ ...formData, name: e.target.value })
@@ -280,7 +280,7 @@ const InspectorPage = () => {
                   <Label htmlFor="username">Username</Label>
                   <Input
                     id="username"
-                    placeholder="Enter inspector username"
+                    placeholder="Masukkan username inspektor"
                     value={formData.username}
                     onChange={(e) =>
                       setFormData({ ...formData, username: e.target.value })
@@ -327,11 +327,11 @@ const InspectorPage = () => {
                   type="submit"
                   className="w-full bg-orange-600 hover:bg-orange-700"
                 >
-                  Create Inspector
+                  Buat Inspektor
                 </Button>
                 <DrawerClose asChild>
                   <Button variant="outline" className="w-full">
-                    Cancel
+                    Batal
                   </Button>
                 </DrawerClose>
               </DrawerFooter>
@@ -345,12 +345,12 @@ const InspectorPage = () => {
         <DrawerContent className="sm:max-w-[425px] fixed right-0 top-0 bottom-0 left-auto">
           <DrawerHeader>
             <DrawerTitle>
-              {isEditing ? "Edit Inspector" : "Inspector Details"}
+              {isEditing ? "Edit Inspektor" : "Detail Inspektor"}
             </DrawerTitle>
             <DrawerDescription>
               {isEditing
-                ? "Update inspector information below."
-                : "View inspector details. Click Edit to modify information."}
+                ? "Perbarui informasi inspektor di bawah."
+                : "Lihat detail inspektor. Klik Edit untuk mengubah informasi."}
             </DrawerDescription>
           </DrawerHeader>
 
@@ -358,7 +358,7 @@ const InspectorPage = () => {
             <form onSubmit={handleUpdateInspector}>
               <div className="mb-5 space-y-4 px-4">
                 <div className="space-y-2">
-                  <Label htmlFor="view-name">Full Name</Label>
+                  <Label htmlFor="view-name">Nama Lengkap</Label>
                   <Input
                     id="view-name"
                     value={viewFormData.name}
@@ -406,7 +406,7 @@ const InspectorPage = () => {
                     onChange={(e) =>
                       setViewFormData({ ...viewFormData, pin: e.target.value })
                     }
-                    placeholder="Enter PIN"
+                    placeholder="Masukkan PIN"
                   />
                 </div>
                 <div className="space-y-2">
@@ -418,16 +418,16 @@ const InspectorPage = () => {
                     }
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select status" />
+                      <SelectValue placeholder="Pilih status" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="active">Active</SelectItem>
-                      <SelectItem value="inactive">Inactive</SelectItem>
+                      <SelectItem value="active">Aktif</SelectItem>
+                      <SelectItem value="inactive">Tidak Aktif</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="view-created">Created At</Label>
+                  <Label htmlFor="view-created">Dibuat Pada</Label>
                   <Input
                     id="view-created"
                     value={viewFormData.createdAt}
@@ -441,7 +441,7 @@ const InspectorPage = () => {
                   type="submit"
                   className="w-full bg-orange-600 hover:bg-orange-700"
                 >
-                  Update Inspector
+                  Perbarui Inspektor
                 </Button>
                 <Button
                   type="button"
@@ -449,7 +449,7 @@ const InspectorPage = () => {
                   className="w-full"
                   onClick={handleCancelEdit}
                 >
-                  Cancel
+                  Batal
                 </Button>
               </DrawerFooter>
             </form>
@@ -457,7 +457,7 @@ const InspectorPage = () => {
             <>
               <div className="mb-5 space-y-4 px-4">
                 <div className="space-y-2">
-                  <Label htmlFor="view-name">Full Name</Label>
+                  <Label htmlFor="view-name">Nama Lengkap</Label>
                   <Input
                     id="view-name"
                     value={viewFormData.name}
@@ -516,7 +516,7 @@ const InspectorPage = () => {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="view-created">Created At</Label>
+                  <Label htmlFor="view-created">Dibuat Pada</Label>
                   <Input
                     id="view-created"
                     value={viewFormData.createdAt}
@@ -532,11 +532,11 @@ const InspectorPage = () => {
                   onClick={handleEditMode}
                 >
                   <FaEdit className="mr-2" />
-                  Edit Inspector
+                  Edit Inspektor
                 </Button>
                 <DrawerClose asChild>
                   <Button variant="outline" className="w-full">
-                    Close
+                    Tutup
                   </Button>
                 </DrawerClose>
               </DrawerFooter>
@@ -552,7 +552,7 @@ const InspectorPage = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-blue-600 dark:text-blue-400">
-                  Total Inspectors
+                  Total Inspektor
                 </p>
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {inspectorList.length}
@@ -570,7 +570,7 @@ const InspectorPage = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-green-600 dark:text-green-400">
-                  Active
+                  Aktif
                 </p>
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {inspectorList.filter((i) => i.status === "active").length}
@@ -588,7 +588,7 @@ const InspectorPage = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-orange-600 dark:text-orange-400">
-                  Branches
+                  Cabang
                 </p>
                 <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {
@@ -610,7 +610,7 @@ const InspectorPage = () => {
         <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
         <input
           type="text"
-          placeholder="Search by name, email, or branch..."
+          placeholder="Cari berdasarkan nama, email, atau cabang..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 dark:focus:ring-orange-400 focus:border-transparent transition-all"
@@ -623,7 +623,7 @@ const InspectorPage = () => {
           <TableHeader>
             <TableRow className="bg-gray-50 dark:bg-gray-900">
               <TableHead className="text-left font-semibold text-gray-900 dark:text-gray-100 py-4 px-6">
-                Name
+                Nama
               </TableHead>
               <TableHead className="text-left font-semibold text-gray-900 dark:text-gray-100 py-4 px-6">
                 Email
@@ -632,10 +632,10 @@ const InspectorPage = () => {
                 Status
               </TableHead>
               <TableHead className="text-left font-semibold text-gray-900 dark:text-gray-100 py-4 px-6">
-                Created At
+                Dibuat Pada
               </TableHead>
               <TableHead className="text-center font-semibold text-gray-900 dark:text-gray-100 py-4 px-6">
-                Actions
+                Aksi
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -757,15 +757,14 @@ const InspectorPage = () => {
                     </div>
                     <div className="text-center max-w-sm">
                       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
-                        No inspectors found
+                        Tidak ada inspektor ditemukan
                       </h3>
                       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                        There are no inspector accounts to display at this time.
+                        Saat ini tidak ada akun inspektor untuk ditampilkan.
                       </p>
                       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mt-4">
                         <p className="text-xs text-blue-800 dark:text-blue-200">
-                          New inspector accounts will appear here after they are
-                          created.
+                          Akun inspektor baru akan muncul di sini setelah dibuat.
                         </p>
                       </div>
                     </div>
@@ -811,11 +810,11 @@ const InspectorPage = () => {
                         className="inline-flex items-center px-3 py-1.5 border border-blue-300 dark:border-blue-600 shadow-sm text-xs font-medium rounded-md text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-800/20 hover:bg-blue-100 dark:hover:bg-blue-700/30 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
                       >
                         <FaEye className="w-3 h-3 mr-1" />
-                        View
+                        Lihat
                       </button>
                       <button className="inline-flex items-center px-3 py-1.5 border border-red-300 shadow-sm text-xs font-medium rounded-md text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors duration-200">
                         <FaTrash className="w-3 h-3 mr-1" />
-                        Delete
+                        Hapus
                       </button>
                     </div>
                   </TableCell>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -55,7 +55,7 @@ const DashboardHeader = ({
         <div className="flex items-center space-x-3">
           <div className="flex items-center px-3 py-2 bg-green-50 rounded-md">
             <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
-            <span className="text-sm font-medium text-green-700">Live</span>
+            <span className="text-sm font-medium text-green-700">Aktif</span>
           </div>
         </div>
       </div>
@@ -244,10 +244,10 @@ const Dashboard: React.FC = () => {
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-            Access Denied
+            Akses Ditolak
           </h2>
           <p className="text-gray-600 dark:text-gray-400">
-            Please log in to access the dashboard.
+            Silakan masuk untuk mengakses dashboard.
           </p>
         </div>
       </div>

--- a/src/app/dashboard/preview/[id]/layout.tsx
+++ b/src/app/dashboard/preview/[id]/layout.tsx
@@ -2,8 +2,8 @@ import { Metadata } from "next";
 import React from "react";
 
 export const metadata: Metadata = {
-  title: "Preview Dashboard",
-  description: "Preview hasil inspeksi kendaraan dari dashboard admin",
+  title: "Pratinjau Dashboard",
+  description: "Pratinjau hasil inspeksi kendaraan dari dashboard admin",
   robots: "noindex, nofollow",
 };
 

--- a/src/app/dashboard/preview/[id]/page.tsx
+++ b/src/app/dashboard/preview/[id]/page.tsx
@@ -448,7 +448,7 @@ function DataPage() {
     // Dynamically add HalamanGeneralPhoto pages
     ...dataHalamanGeneralPhotos.map((photosChunk, index) => ({
       id: 7 + index, // Adjust ID based on previous pages
-      title: `Foto General - Part ${index + 1}`,
+      title: `Foto General - Bagian ${index + 1}`,
       component: (
         <HalamanGeneralPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -456,7 +456,7 @@ function DataPage() {
     // Dynamically add HalamanExteriorPhoto pages
     ...dataHalamanExteriorPhotos.map((photosChunk, index) => ({
       id: 7 + dataHalamanGeneralPhotos.length + index, // Adjust ID based on previous pages
-      title: `Foto Eksterior - Part ${index + 1}`,
+      title: `Foto Eksterior - Bagian ${index + 1}`,
       component: (
         <HalamanExteriorPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -468,7 +468,7 @@ function DataPage() {
         dataHalamanGeneralPhotos.length +
         dataHalamanExteriorPhotos.length +
         index, // Adjust ID based on previous pages and new exterior photo pages
-      title: `Foto Interior - Part ${index + 1}`,
+      title: `Foto Interior - Bagian ${index + 1}`,
       component: (
         <HalamanInteriorPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -481,7 +481,7 @@ function DataPage() {
         dataHalamanExteriorPhotos.length +
         dataHalamanInteriorPhotos.length +
         index,
-      title: `Foto Mesin - Part ${index + 1}`,
+      title: `Foto Mesin - Bagian ${index + 1}`,
       component: (
         <HalamanMesinPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -495,7 +495,7 @@ function DataPage() {
         dataHalamanInteriorPhotos.length +
         dataHalamanMesinPhotos.length +
         index,
-      title: `Foto Kaki-Kaki - Part ${index + 1}`,
+      title: `Foto Kaki-Kaki - Bagian ${index + 1}`,
       component: (
         <HalamanKakiKakiPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -510,7 +510,7 @@ function DataPage() {
         dataHalamanMesinPhotos.length +
         dataHalamanKakiKakiPhotos.length +
         index,
-      title: `Foto Alat-Alat - Part ${index + 1}`,
+      title: `Foto Alat-Alat - Bagian ${index + 1}`,
       component: (
         <HalamanAlatAlatPhoto data={{ photos: photosChunk }} editable={false} />
       ),
@@ -526,7 +526,7 @@ function DataPage() {
         dataHalamanKakiKakiPhotos.length +
         dataHalamanAlatPhotos.length +
         index,
-      title: `Foto Dokumen - Part ${index + 1}`,
+      title: `Foto Dokumen - Bagian ${index + 1}`,
       component: (
         <HalamanFotoDokumen data={{ photos: photosChunk }} editable={false} />
       ),
@@ -568,7 +568,7 @@ function DataPage() {
         dataHalamanAlatPhotos.length +
         dataHalamanFotoDokumenPhotos.length +
         index,
-      title: `Perlu Perhatian - Part ${index + 1}`,
+      title: `Perlu Perhatian - Bagian ${index + 1}`,
       description: `Dokumentasi foto perlu perhatian bagian ${index + 1}`,
       component: (
         <HalamanPerluPerhatianPhoto
@@ -602,7 +602,7 @@ function DataPage() {
           }}
           className="bg-blue-500 text-white hover:bg-blue-700"
         >
-          <IoArrowBack /> Back
+          <IoArrowBack /> Kembali
         </Button>
       </div>
       <div className="absolute top-5 right-5 no-print">
@@ -612,7 +612,7 @@ function DataPage() {
           }}
           className="bg-orange-600 text-white hover:bg-orange-700"
         >
-          <IoMdDownload /> Download Preview
+          <IoMdDownload /> Unduh Pratinjau
         </Button>
       </div>
       <div className="sheet-outer A4">

--- a/src/app/dashboard/review/[id]/layout.tsx
+++ b/src/app/dashboard/review/[id]/layout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Review Detail",
+  title: "Detail Review",
   description: "Detail review inspeksi kendaraan yang memerlukan persetujuan",
   robots: "noindex, nofollow",
 };

--- a/src/app/dashboard/review/[id]/page.tsx
+++ b/src/app/dashboard/review/[id]/page.tsx
@@ -33,8 +33,8 @@ const Header = ({
     const previewUrl = `https://cardano-pdf.vercel.app/data/${id}`;
     navigator.clipboard.writeText(previewUrl);
     toast({
-      title: "Link Copied!",
-      description: "Preview link has been copied to clipboard.",
+      title: "Tautan Disalin!",
+      description: "Tautan pratinjau telah disalin ke papan klip.",
       variant: "default",
     });
   };
@@ -46,8 +46,8 @@ const Header = ({
   const handleApproveClick = () => {
     if (hasChanges > 0) {
       toast({
-        title: "Cannot Approve",
-        description: "Please save all changes before approving the inspection.",
+        title: "Tidak Dapat Menyetujui",
+        description: "Harap simpan semua perubahan sebelum menyetujui inspeksi.",
         variant: "destructive",
       });
       return;
@@ -95,13 +95,13 @@ const Header = ({
             onClick={handleGetLinkPreview}
             className="bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
           >
-            Get Link Preview
+            Dapatkan Tautan Pratinjau
           </Button>
           <Button
             onClick={handlePreview}
             className="bg-blue-500 text-white hover:bg-blue-600"
           >
-            Preview
+            Pratinjau
           </Button>
           <Button
             onClick={handleApproveClick}
@@ -111,7 +111,7 @@ const Header = ({
                 ? "bg-gray-400 text-gray-600 cursor-not-allowed"
                 : "bg-green-500 text-white hover:bg-green-600"
             } disabled:opacity-50 disabled:cursor-not-allowed transition-colors`}
-            title={hasChanges > 0 ? "Save changes before approving" : ""}
+            title={hasChanges > 0 ? "Simpan perubahan sebelum menyetujui" : ""}
           >
             <svg
               className="w-4 h-4 mr-2"
@@ -419,8 +419,8 @@ const Edit = () => {
         };
       });
       toast({
-        title: "Photo Added",
-        description: "New photo has been successfully added.",
+        title: "Foto Ditambahkan",
+        description: "Foto baru telah berhasil ditambahkan.",
         variant: "default",
       });
     } else {
@@ -451,24 +451,24 @@ const Edit = () => {
       if (response) {
         setData(response);
         toast({
-          title: "Data loaded successfully",
-          description: "Inspection data is ready for review.",
+          title: "Data berhasil dimuat",
+          description: "Data inspeksi siap untuk direview.",
           variant: "default",
         });
       }
     } catch (error) {
       toast({
-        title: "Error loading data",
-        description: "An error occurred while fetching the inspection data.",
+        title: "Gagal memuat data",
+        description: "Terjadi kesalahan saat mengambil data inspeksi.",
         variant: "destructive",
       });
       setDialogResultData({
         isOpen: true,
         isSuccess: false,
-        title: "Data Not Found",
+        title: "Data Tidak Ditemukan",
         message:
-          "Could not fetch the inspection data. It may not exist or an error occurred.",
-        buttonLabel2: "Back to Review List",
+          "Tidak dapat mengambil data inspeksi. Mungkin tidak ada atau terjadi kesalahan.",
+        buttonLabel2: "Kembali ke Daftar Review",
         action2: () => router.push("/dashboard/review"),
       });
     }
@@ -602,17 +602,17 @@ const Edit = () => {
 
       // Show toast notification for confirmation
       toast({
-        title: "Field updated",
+        title: "Isian diperbarui",
         description: `${subsubfieldname ? `` : fieldName}${
           desc ? ` ${desc}` : ``
-        } has been updated.`,
+        } telah diperbarui.`,
         variant: "default",
       });
     } catch (error) {
       console.error("Error updating data:", error);
       toast({
-        title: "Update failed",
-        description: "Could not update the field value.",
+        title: "Pembaruan gagal",
+        description: "Tidak dapat memperbarui nilai isian.",
         variant: "destructive",
       });
     }
@@ -650,10 +650,10 @@ const Edit = () => {
         setDialogResultData({
           isOpen: true,
           isSuccess: true,
-          title: "Successfully Minted to Blockchain",
+          title: "Berhasil Dicetak ke Blockchain",
           message:
-            "The inspection data has been successfully approved and minted to the blockchain. You can view it in the database.",
-          buttonLabel2: "View in Database",
+            "Data inspeksi telah berhasil disetujui dan dicetak ke blockchain. Anda dapat melihatnya di database.",
+          buttonLabel2: "Lihat di Database",
           action2: () => router.push("/dashboard/database"),
         });
       })
@@ -662,11 +662,11 @@ const Edit = () => {
         setDialogResultData({
           isOpen: true,
           isSuccess: false,
-          title: "Minting Failed",
+          title: "Pencetakan Gagal",
           message:
-            "Failed to mint data to the blockchain. Would you like to try again?",
-          buttonLabel1: "Cancel",
-          buttonLabel2: "Try Again",
+            "Gagal mencetak data ke blockchain. Apakah Anda ingin mencoba lagi?",
+          buttonLabel1: "Batal",
+          buttonLabel2: "Coba Lagi",
           action1: () => router.push("/dashboard/database"),
           action2: () => {
             mintingToBlockchainHandler(id);
@@ -686,11 +686,11 @@ const Edit = () => {
           setDialogResultData({
             isOpen: true,
             isSuccess: true,
-            title: "Inspection Approved",
+            title: "Inspeksi Disetujui",
             message:
-              "The inspection data has been approved. Would you like to proceed with minting to the blockchain?",
-            buttonLabel1: "Later",
-            buttonLabel2: "Mint to Blockchain",
+              "Data inspeksi telah disetujui. Apakah Anda ingin melanjutkan dengan pencetakan ke blockchain?",
+            buttonLabel1: "Nanti",
+            buttonLabel2: "Cetak ke Blockchain",
             action1: () => router.push("/dashboard/database"),
             action2: () => {
               setDialogResultData(null); // Close the current dialog
@@ -701,11 +701,11 @@ const Edit = () => {
           setDialogResultData({
             isOpen: true,
             isSuccess: false,
-            title: "Approval Failed",
+            title: "Persetujuan Gagal",
             message:
-              "This data may have been previously approved or there's an issue with the approval process.",
-            buttonLabel1: "Back to Database",
-            buttonLabel2: "Try Again",
+              "Data ini mungkin telah disetujui sebelumnya atau ada masalah dengan proses persetujuan.",
+            buttonLabel1: "Kembali ke Database",
+            buttonLabel2: "Coba Lagi",
             action1: () => router.push("/dashboard/database"),
             action2: () => router.push("/dashboard/review"),
           });
@@ -716,10 +716,10 @@ const Edit = () => {
         setDialogResultData({
           isOpen: true,
           isSuccess: false,
-          title: "Approval Failed",
-          message: "An error occurred while approving the inspection data.",
-          buttonLabel1: "Back to Database",
-          buttonLabel2: "Try Again",
+          title: "Persetujuan Gagal",
+          message: "Terjadi kesalahan saat menyetujui data inspeksi.",
+          buttonLabel1: "Kembali ke Database",
+          buttonLabel2: "Coba Lagi",
           action1: () => router.push("/dashboard/database"),
           action2: () => approveInspection(),
         });
@@ -729,8 +729,8 @@ const Edit = () => {
   const handleSaveChanges = () => {
     if (!unsavedChanges || unsavedChanges.length === 0) {
       toast({
-        title: "No changes to save",
-        description: "You haven't made any changes to the inspection data.",
+        title: "Tidak ada perubahan untuk disimpan",
+        description: "Anda belum membuat perubahan apa pun pada data inspeksi.",
         variant: "default",
       });
       return;
@@ -770,10 +770,10 @@ const Edit = () => {
           setDialogResultData({
             isOpen: true,
             isSuccess: true,
-            title: "Changes Saved Successfully",
-            message: "Your changes to the inspection data have been saved.",
-            buttonLabel1: "Back to Review List",
-            buttonLabel2: "View Updated Data",
+            title: "Perubahan Berhasil Disimpan",
+            message: "Perubahan Anda pada data inspeksi telah disimpan.",
+            buttonLabel1: "Kembali ke Daftar Review",
+            buttonLabel2: "Lihat Data Terbaru",
             action1: () => router.push("/dashboard/review"),
             action2: () => window.location.reload(),
           });
@@ -783,11 +783,11 @@ const Edit = () => {
           setDialogResultData({
             isOpen: true,
             isSuccess: false,
-            title: "Failed to Save Changes",
+            title: "Gagal Menyimpan Perubahan",
             message:
-              "An error occurred while saving your changes. Please try again.",
-            buttonLabel1: "Back to Draft Review",
-            buttonLabel2: "Try Again",
+              "Terjadi kesalahan saat menyimpan perubahan Anda. Silakan coba lagi.",
+            buttonLabel1: "Kembali ke Draf Review",
+            buttonLabel2: "Coba Lagi",
             action1: () => router.push("/dashboard/review"),
             action2: () => handleSaveChanges(),
           });

--- a/src/app/dashboard/review/layout.tsx
+++ b/src/app/dashboard/review/layout.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Draft Review",
+  title: "Draf Review",
   description:
-    "Review dan kelola draft inspeksi kendaraan yang memerlukan persetujuan",
+    "Review dan kelola draf inspeksi kendaraan yang memerlukan persetujuan",
   robots: "noindex, nofollow",
 };
 

--- a/src/app/dashboard/review/page.tsx
+++ b/src/app/dashboard/review/page.tsx
@@ -38,7 +38,7 @@ const Header = ({
           </div>
           <div>
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-              Draft Reviewer
+              Draf Reviewer
             </h1>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
               {dataCount > 0

--- a/src/app/dashboard/usermanagement/page.tsx
+++ b/src/app/dashboard/usermanagement/page.tsx
@@ -40,7 +40,7 @@ const Header = ({
           </div>
           <div>
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-              User Management
+              Manajemen Pengguna
             </h1>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
               {userCount > 0
@@ -72,7 +72,7 @@ const Header = ({
           <div className="flex items-center px-3 py-2 bg-green-50 dark:bg-green-900 rounded-md">
             <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
             <span className="text-sm font-medium text-green-700 dark:text-green-300">
-              Active
+              Aktif
             </span>
           </div>
         </div>
@@ -104,7 +104,7 @@ const SearchBar = ({ setQuery, setFilter }: any) => {
             type="text"
             id="search-navbar"
             className="block w-full p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-            placeholder="Search..."
+            placeholder="Cari..."
             onChange={(e) => setKeyword(e.target.value)}
           />
         </form>
@@ -138,7 +138,7 @@ const Database: React.FC = () => {
         console.log(error);
         toast({
           title: "Error",
-          description: error,
+          description: "Gagal mengambil data",
           variant: "destructive",
         });
       });

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -319,9 +319,9 @@ function ResultPageContent() {
 
             {/* Download data */}
             <div className="w-full flex justify-center lg:justify-between items-end text-neutral-900 font-light mt-5 lg:mt-10 mb-5">
-              <p className="hidden lg:block w-1/2 text-4xl">
-                Download laporan inspeksi lengkap <br /> (19 halaman PDF)
-              </p>
+          <p className="hidden lg:block w-1/2 text-4xl">
+            Unduh laporan inspeksi lengkap <br /> (PDF 19 halaman)
+          </p>
               <div className="z-10 flex flex-wrap justify-start items-center gap-3 sm:gap-5 mt-4 sm:mt-5">
                 <Image
                   src="/assets/logo/pdf.svg"
@@ -332,7 +332,7 @@ function ResultPageContent() {
                 />
                 <CustomButton className="text-[clamp(16px,3vw,28px)] font-white font-light rounded-full gradient-details text-white">
                   <a href={`${PDF_URL}${review.urlPdf}`} download>
-                    Download Detail (PDF)
+                    Unduh Detail (PDF)
                   </a>
                 </CustomButton>
               </div>
@@ -508,7 +508,7 @@ function ResultPageContent() {
 
 export default function ResultPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div>Memuat...</div>}>
       <ResultPageContent />
     </Suspense>
   );


### PR DESCRIPTION
### update

*   Translated static UI text from English to Indonesian across all dashboard pages to provide localization. Fixes #25
    *   Updated `metadata` in layout files (`review`, `preview`, `inspector`, etc.) with Indonesian titles and descriptions.
    *   Localized text within various components, including headers, buttons, form labels, and placeholders on pages such as `dashboard/page.tsx`, `dashboard/database/page.tsx`, `dashboard/inspector/page.tsx`, and `dashboard/review/[id]/page.tsx`.
    *   Translated dynamic user-facing messages, including `toast` notifications and `DialogResult` text, for actions like data loading, updates, approvals, and errors.
    *   Standardized status indicators and labels (e.g., "Approved" to "Disetujui", "Live" to "Aktif") to their Indonesian equivalents.