### PR TITLE
fix(ui): Correct grade label mapping

### DIFF
--- a/src/components/Preview/Halaman1.tsx
+++ b/src/components/Preview/Halaman1.tsx
@@ -243,16 +243,16 @@ const Halaman1: React.FC<Halaman1Props> = ({
 
   function getGradeLabel(score: number): string {
     const gradingScale: { [key: number]: string } = {
-      0: "E",
-      1: "D-",
-      2: "D",
-      3: "C-",
-      4: "C",
-      5: "B-",
-      6: "B",
-      7: "B+",
-      8: "A-",
-      9: "A",
+      0: "-",
+      1: "E",
+      2: "D-",
+      3: "D",
+      4: "C-",
+      5: "C",
+      6: "B-",
+      7: "B",
+      8: "B+",
+      9: "A-",
       10: "A",
     };
 

--- a/src/components/ui/Card/CardHasil.tsx
+++ b/src/components/ui/Card/CardHasil.tsx
@@ -5,16 +5,16 @@ import Image from "next/image";
 function CardHasil({ inspectionSummary, overallRating, urlPdf }: any) {
   function getGradeLabel(score: number): string {
     const gradingScale: { [key: number]: string } = {
-      0: "E",
-      1: "D-",
-      2: "D",
-      3: "C-",
-      4: "C",
-      5: "B-",
-      6: "B",
-      7: "B+",
-      8: "A-",
-      9: "A",
+      0: "-",
+      1: "E",
+      2: "D-",
+      3: "D",
+      4: "C-",
+      5: "C",
+      6: "B-",
+      7: "B",
+      8: "B+",
+      9: "A-",
       10: "A",
     };
 


### PR DESCRIPTION
### 🐛 Bug Fixes

*   Modified the `gradingScale` lookup object in the `getGradeLabel` function within `Halaman1.tsx` and `CardHasil.tsx`.
*   The score-to-grade mapping was shifted to resolve an off-by-one error where the displayed grade was one level higher than intended. Fixes #37
*   A new entry was added to map a score of `0` to `"-"`.