### PR TITLE
fix(dashboard): Correctly display top 10 inspectors by performance

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -392,10 +392,7 @@ const Dashboard: React.FC = () => {
             </div>
             <div className="lg:col-span-2 border-none h-full">
               <InspectorPerfomance
-                data={combinedDashboardData.inspectorPerformance.data.slice(
-                  0,
-                  10
-                )}
+                data={combinedDashboardData.inspectorPerformance.data}
               />
             </div>
           </div>

--- a/src/components/Dashboard/InspectorPerfomance.tsx
+++ b/src/components/Dashboard/InspectorPerfomance.tsx
@@ -5,9 +5,9 @@ function InspectorPerfomance({
 }: {
   data?: { inspector: string; totalInspections: number }[];
 }) {
-  const sortedData = [...data].sort(
-    (a, b) => b.totalInspections - a.totalInspections
-  );
+  const sortedAndSlicedData = [...data]
+    .sort((a, b) => b.totalInspections - a.totalInspections)
+    .slice(0, 10); // Take only the top 10 after sorting
 
   return (
     <div className="font-inter bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 ">
@@ -17,7 +17,7 @@ function InspectorPerfomance({
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {sortedData.map((item, index) => (
+            {sortedAndSlicedData.map((item, index) => (
               <tr key={index}>
                 <td className="px-6 py-[5px] whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                   {index + 1}. {item.inspector}


### PR DESCRIPTION
### 🐛 Bug Fixes

*   Modified the `InspectorPerfomance` component to sort the full list of inspectors by performance *before* slicing the top 10 for display. Previously, the data was sliced before being passed to the component, resulting in an inaccurate list. Fixes #40

before:
<img width="878" height="812" alt="image" src="https://github.com/user-attachments/assets/3c89344a-52b2-4c9b-a1ef-b2727dcfb9db" />

after:
<img width="867" height="814" alt="image" src="https://github.com/user-attachments/assets/8d2d53ff-d438-4b0d-8f92-fadbc2598cc6" />
