### PR TITLE
feat(navbar): Implement sticky, auto-hiding navbar

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,12 +1,33 @@
 "use client";
-
+import { useState, useEffect } from "react";
 import Footer from "./Footer";
 import Navbar from "./Navbar";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
+  const [isNavbarVisible, setIsNavbarVisible] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  const handleScroll = () => {
+    if (window.scrollY > lastScrollY) {
+      // Scrolling down
+      setIsNavbarVisible(false);
+    } else {
+      // Scrolling up
+      setIsNavbarVisible(true);
+    }
+    setLastScrollY(window.scrollY);
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [lastScrollY]);
   return (
     <div className="flex flex-col min-h-screen">
-      <Navbar />
+      <Navbar isNavbarVisible={isNavbarVisible} />
       <div className="flex flex-1">
         <main className="flex-1 w-full">{children}</main>
       </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -19,7 +19,11 @@ import {
   AlertDialogTrigger,
 } from "../ui/alert-dialog";
 
-const Navbar = () => {
+interface NavbarProps {
+  isNavbarVisible: boolean;
+}
+
+const Navbar = ({ isNavbarVisible }: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
   const user = useAppSelector((state) => state.auth.user);
@@ -50,7 +54,11 @@ const Navbar = () => {
   }
 
   return (
-    <nav className=" font-rubik w-full bg-white text-white px-6 md:px-14 py-4 flex justify-between items-center navbar-shadow">
+    <nav
+      className={`font-rubik w-full bg-white text-white px-6 md:px-14 py-4 flex justify-between items-center navbar-shadow sticky top-0 z-50 transition-transform duration-300 ${
+        isNavbarVisible ? "translate-y-0" : "-translate-y-full"
+      }`}
+    >
       {/* Logo */}
       <div onClick={handleToHome} className="flex gap-2 cursor-pointer">
         <Image


### PR DESCRIPTION
### ✨ New Functionality

*   Makes the main navigation bar sticky, fixing it to the top of the viewport during scroll.
*   The navbar now automatically hides on scroll down and reappears on scroll up to maximize screen real estate. Closes #56
*   The parent `Layout` component now tracks scroll direction and passes a visibility state prop to the `Navbar`.
*   The `Navbar` component uses CSS transforms and transitions for a smooth hide/show animation.